### PR TITLE
制作了一些令编译变得更容易操作的脚本（后来又修了个问题

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,6 +8,11 @@ image:
 platform:
   - x86
 
+configuration:
+  - Debug
+  - Release
+  
+  
 environment:
   VCPKG_ROOT: C:\tools\vcpkg
   VCPKG_TRIPLET: my-x86-windows-static
@@ -23,7 +28,5 @@ install:
   - vcpkg --triplet %VCPKG_TRIPLET% install boost-algorithm libiconv
 
 build_script:
-  - powershell scripts/generate.ps1 Debug
-  - powershell scripts/build.ps1 Debug
-  - powershell scripts/generate.ps1 Release
-  - powershell scripts/build.ps1 Release
+  - powershell scripts/generate.ps1 %CONFIGURATION%
+  - powershell scripts/build.ps1 %CONFIGURATION%

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,7 +13,6 @@
             ],
             "options": {
                 "env": {
-                    "VCPKG_ROOT": "C:\\CLI\\vcpkg",
                     "VCPKG_TRIPLET": "my-x86-windows-static"
                 }
             },
@@ -31,7 +30,6 @@
             ],
             "options": {
                 "env": {
-                    "VCPKG_ROOT": "C:\\CLI\\vcpkg",
                     "VCPKG_TRIPLET": "my-x86-windows-static"
                 }
             },

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,7 +1,6 @@
 {
     "environments": [
         {
-            "VCPKG_ROOT": "C:\\CLI\\vcpkg",
             "VCPKG_CMAKE": "${env.VCPKG_ROOT}\\scripts\\buildsystems\\vcpkg.cmake",
             "VCPKG_TRIPLET": "my-x86-windows-static"
         }

--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ CoolQ C++ SDK 封装了跟 DLL 接口相关的底层逻辑，包括：
 
 请点击[Vcpkg](https://github.com/Microsoft/vcpkg)前往vcpkg主页，跟随其引导配置vcpkg环境。  
 请设置环境变量 `VCPKG_ROOT` 为上面所的vcpkg根目录。   
-运行目录下的 `build_envir.bat` 来构建所有的依赖项。  
-依赖项安装完毕之后，无需重新使用 `build_envir.bat` 下载依赖项。  
+运行目录下的 `build_envir.bat` 来构建所有的依赖项。   
 
-依赖项构建完毕后，运行 `build_debug.bat` 和 `build_release.bat` 来产生构建文件。  
-在 `.vscode/` 文件夹中已经有针对VS Code的构建配置，使用 `Terminal -> Run Task` 来产生构建。  
+依赖项构建完毕后，运行 `build_debug.bat` 和 `build_release.bat` 来生成 DLL 文件。  
+如果已经构建完依赖项，在生成 DLL 文件时，无需重新使用 `build_envir.bat` 来构建依赖项。  
+
+除此之外，在 `.vscode/` 文件夹中已经有针对VS Code的构建配置，使用 `Terminal -> Run Task` 来产生构建。  
 
 构建成功后，可以在 `build/Debug/Debug` 或 `build/Release/Release` 中找到生成的 DLL 和 JSON 文件，直接拷贝到酷 Q 的 `app` 目录即可测试使用（酷 Q 需要开启开发模式）。
 

--- a/README.md
+++ b/README.md
@@ -24,29 +24,15 @@ CoolQ C++ SDK 封装了跟 DLL 接口相关的底层逻辑，包括：
 
 可以直接用 VS Code 或 VS 打开项目，项目中的所有代码文件全部使用 UTF-8 编码，你后续添加的所有代码文件都需要使用 UTF-8 编码。**注意，如果你使用 VS，则它默认使用 ANSI 编码保存文件，需要手动修改为 UTF-8**。[`com.example.demo.json`](com.example.demo.json) 文件将在 [`scripts/post_build.ps1`](scripts/post_build.ps1) 脚本中被转换为酷 Q 要求的 GB18030 编码。
 
-Vcpkg 使用如下 triplet：
+本项目中的脚本依赖于[PowerShell](https://github.com/PowerShell/PowerShell)，大部分windows电脑预装了PowerShell，但如果你的电脑没有PowerShell，可以前往其主页获取。  
 
-```cmake
-set(VCPKG_TARGET_ARCHITECTURE x86)
-set(VCPKG_CRT_LINKAGE dynamic)
-set(VCPKG_LIBRARY_LINKAGE static)
-set(VCPKG_PLATFORM_TOOLSET v141)
-```
+请点击[Vcpkg](https://github.com/Microsoft/vcpkg)前往vcpkg主页，跟随其引导配置vcpkg环境。  
+请设置环境变量 `VCPKG_ROOT` 为上面所的vcpkg根目录。   
+运行目录下的 `build_envir.bat` 来构建所有的依赖项。  
+依赖项安装完毕之后，无需重新使用 `build_envir.bat` 下载依赖项。  
 
-你需要在 Vcpkg 的 `triplets` 文件夹中创建一个名为 `my-x86-windows-static.cmake` 的文件（文件名可以换为其它，但建议保留 `x86-windows-static` 这部分，似乎 Vcpkg 使用了文件名来判断要安装的包的版本），内容如上。创建了这个 triplet 之后，你需要将 [`scripts/generate.ps1`](scripts/generate.ps1) 中的 `$vcpkg_root`（vcpkg 根目录）和 `$vcpkg_triplet`（triplet 名称，例如 `my-x86-windows-static`）设置成你系统中的相应值（或设置环境变量），如果你使用 VS Code 或 VS 编辑项目，可以直接修改 `.vscode/tasks.json`（VS Code）或 `CMakeSettings.json`（VS）中的 `VCPKG_ROOT` 和 `VCPKG_TRIPLET` 环境变量，**注意，`.vscode/tasks.json` 中有两个 task 需要改**。
-
-除此之外，还需要安装如下依赖（使用上面的 triplet）：
-
-| 模块 | 依赖项 |
-| --- | ----- |
-| `cqsdk` | `boost-algorithm`<br>`libiconv` |
-
-安装命令如下：
-
-```ps1
-cd vcpkg
-.\vcpkg --vcpkg-root . --triplet my-x86-windows-static install boost-algorithm libiconv
-```
+依赖项构建完毕后，运行 `build_debug.bat` 和 `build_release.bat` 来产生构建文件。  
+在 `.vscode/` 文件夹中已经有针对VS Code的构建配置，使用 `Terminal -> Run Task` 来产生构建。  
 
 构建成功后，可以在 `build/Debug/Debug` 或 `build/Release/Release` 中找到生成的 DLL 和 JSON 文件，直接拷贝到酷 Q 的 `app` 目录即可测试使用（酷 Q 需要开启开发模式）。
 

--- a/build_debug.bat
+++ b/build_debug.bat
@@ -1,0 +1,4 @@
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy Bypass %~dp0scripts\generate.ps1 debug
+powershell.exe -NoProfile -ExecutionPolicy Bypass %~dp0scripts\build.ps1 debug
+explorer %~dp0build\debug\debug

--- a/build_envir.bat
+++ b/build_envir.bat
@@ -1,0 +1,3 @@
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy Bypass %~dp0scripts\build_env.ps1
+pause

--- a/build_envir.bat
+++ b/build_envir.bat
@@ -1,3 +1,3 @@
 @echo off
-powershell.exe -NoProfile -ExecutionPolicy Bypass %~dp0scripts\build_env.ps1
+powershell.exe -NoProfile -ExecutionPolicy Bypass %~dp0scripts\check_env.ps1
 pause

--- a/build_release.bat
+++ b/build_release.bat
@@ -1,0 +1,4 @@
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy Bypass %~dp0scripts\generate.ps1 release
+powershell.exe -NoProfile -ExecutionPolicy Bypass %~dp0scripts\build.ps1 release
+explorer %~dp0build\release\release

--- a/scripts/check_env.ps1
+++ b/scripts/check_env.ps1
@@ -1,0 +1,31 @@
+﻿$VCPKG_TRIPLET = 'my-x86-windows-static'
+
+$startloc = $PSScriptRoot
+
+$VCPKG_RT = ${env:VCPKG_ROOT}
+if ($null -eq $VCPKG_RT)
+{
+	Write-Warning "Could not find VCPKG_ROOT. Please set up vcpkg environment."
+	exit
+}
+
+$VCPKG_EXE = "$VCPKG_RT\vcpkg.exe"
+if (!(Test-Path $VCPKG_EXE)){
+	Write-Warning "Invalid VCPKG_ROOT. Please check vcpkg environment."
+	exit
+}
+
+$TRIPLET_TARGET = "$VCPKG_RT\triplets\$VCPKG_TRIPLET.cmake"
+
+Write-Host "Vcpkg root found at : $env:VCPKG_ROOT" -ForegroundColor Green
+Write-Host "Creating triplets : $VCPKG_TRIPLET"-ForegroundColor Green
+Write-Output 'set(VCPKG_TARGET_ARCHITECTURE x86)'	| Out-File -FilePath $TRIPLET_TARGET -Encoding utf8
+Write-Output 'set(VCPKG_CRT_LINKAGE dynamic)' 		| Out-File -FilePath $TRIPLET_TARGET -Encoding utf8 -Append
+Write-Output 'set(VCPKG_LIBRARY_LINKAGE static)' 	| Out-File -FilePath $TRIPLET_TARGET -Encoding utf8 -Append
+Write-Output 'set(VCPKG_PLATFORM_TOOLSET v141)'   	| Out-File -FilePath $TRIPLET_TARGET -Encoding utf8 -Append
+
+Write-Host "Building denpendecies..."
+Set-Location -Path $VCPKG_RT
+.\vcpkg --triplet $VCPKG_TRIPLET install libiconv boost-algorithm
+Set-Location -Path $startloc
+Write-Host "Building of dependencies completed." -ForegroundColor Green

--- a/scripts/generate.ps1
+++ b/scripts/generate.ps1
@@ -5,7 +5,7 @@ mkdir build\$config_type -ErrorAction SilentlyContinue  # create build folder if
 Set-Location .\build\$config_type  # enter the build folder
 
 $vcpkg_root = $env:VCPKG_ROOT
-$vcpkg_triplet = $env:VCPKG_TRIPLET
+$vcpkg_triplet = 'my-x86-windows-static'
 
 cmake -G "Visual Studio 15 2017" -T "v141" `
     -DCMAKE_TOOLCHAIN_FILE="$vcpkg_root\scripts\buildsystems\vcpkg.cmake" `


### PR DESCRIPTION
将VCPKG_ROOT的配置转移到外部，使用系统环境变量来控制。  

增加了几个脚本：  
* check_env.ps1 检查VCPKG_ROOT的配置是否正确，并执行依赖项配置。
* build_envir.bat 运行check_env.ps1，但这样写更醒目。
* build_debug.bat 更加醒目和小白的build_debug，甚至会打开生成文件夹。
* build_release.bat 同上，只是配置改为了release。

除此之外：  
改了改appveyor.yml，debug release分开看log比较清楚。
改了改readme.md，写了写这些脚本怎么用的。

后来的改动：
build_envir.bat里调用check_envir.ps1写错了文件名。